### PR TITLE
Replacing database variables with env variables to replace automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,7 @@ Temporary Items
 
 # Firebase Service Account credentials
 service-account-key.json
+
+# Custom RRC files
+./database_connect.php
+./memberLogin.php

--- a/database_connect.php
+++ b/database_connect.php
@@ -1,5 +1,5 @@
 <?php
-$host = '127.0.0.1';
+$host = getenv('DB_HOST');
 $port = getenv('DB_PORT');
 $database = 'reck_club';
 $username = getenv('DB_USER');

--- a/database_connect.php
+++ b/database_connect.php
@@ -1,12 +1,12 @@
 <?php
-	$host = 'localhost';
-	$port = 3306;
-	$database = 'reck_club';
-	$username = 'reck';
-	$password = 'burdell';
-	
-	$dsn = "mysql:host=$host;port=$port;dbname=$database";
-	
-	$db = new PDO($dsn, $username, $password);
-	
+$host = '127.0.0.1';
+$port = getenv('DB_PORT');
+$database = 'reck_club';
+$username = getenv('DB_USER');
+$password = getenv('DB_PASSWORD');
+
+$dsn = "mysql:host=$host;port=$port;dbname=$database";
+
+$db = new PDO($dsn, $username, $password);
+
 ?>


### PR DESCRIPTION
This will help local development, but **these vars will need to be replaced on every deployment to the live site like the others so that the points site will work**.

This will also require a setup docs update to note the creation of a .env file and the addition of DB_USER, DB_PASSWORD, DB_HOST, and DB_PORT (all of the relevant vars for a connection to the mysql db).