### PR TITLE
Updating the Points Website with more Long term Records

### DIFF
--- a/allTimeEvents.php
+++ b/allTimeEvents.php
@@ -65,13 +65,14 @@ krsort($eventCounts, 1);
                             break; // Only show the top 100...Helping performance for future
                         }
                         $totalEvents = $key;
+                        $memberId = $eventCount[0];
                         $firstName = $eventCount[1];
                         $lastName = $eventCount[2];
                         $totalPossibleEvents = $eventCount[3];
                         $name = $firstName . ' ' . $lastName;
                         echo "<tr>";
                         echo "<td>" . $count . "</td>";
-                        echo "<td>" . $name . "</td>";
+                        echo "<td>" . '<a href="/memberProfile.php?memberId=' . $memberId . '">' . $name . '</a>' . "</td>";
                         $eventPct= number_format(($totalEvents/$totalPossibleEvents)*100,1);
                         echo "<td>" . $totalEvents . "/" . $totalPossibleEvents . " (" . $eventPct . "%)</td></tr>";
                         $count++;

--- a/allTimeEvents.php
+++ b/allTimeEvents.php
@@ -50,7 +50,9 @@ krsort($eventCounts, 1);
 <?php require "partials/head.php"; ?>
 <body>
 <?php require "partials/header.php"; ?>
-
+<div class="container">
+    <h2>All-Time Events Top 100</h2>
+</div>
 <div class="container">
     <div class="row mb-3">
         <div class="col-12">

--- a/allTimeEvents.php
+++ b/allTimeEvents.php
@@ -1,0 +1,74 @@
+<?php
+require "logged_in_check.php";
+require "database_connect.php";
+require "set_session_vars_short.php";
+$pageTitle = "All Time Events";
+?>
+
+<?php
+
+$query = $db->prepare("SELECT memberID FROM Member");
+$query->execute();
+$result = $query->fetchAll(PDO::FETCH_COLUMN);
+$eventCounts = array();
+if (count($result) > 0) {
+    foreach($result as $key=>$id){
+        $query = $db->prepare("SELECT firstName, lastName FROM Member WHERE memberID=:id");
+        $query->execute(array('id'=>$id));
+        $query->setFetchMode(PDO::FETCH_ASSOC);
+        $row = $query->fetch();
+        $FirstName = $row['firstName'];
+        $LastName = $row['lastName'];
+        $attendanceQuery = $db->prepare("SELECT eventId from reck_club.AttendsEvent WHERE memberID=:id");
+        $attendanceQuery->execute(array('id'=>$id));
+        $attendanceQuery->setFetchMode(PDO::FETCH_ASSOC);
+        $eventIds = [];
+        while ($row = $attendanceQuery->fetch()) {
+            $eventIds[] = $row['eventId'];
+        }
+        $eventCounts[sizeof($eventIds)] = array($id, $FirstName, $LastName);
+    }
+}
+krsort($eventCounts, 1);
+?>
+
+<!DOCTYPE html>
+<html>
+<?php require "partials/head.php"; ?>
+<body>
+<?php require "partials/header.php"; ?>
+
+<div class="container">
+    <div class="row mb-3">
+        <div class="col-12">
+            <table class="table table-hover table-sm mb-3">
+                <?php
+                if (sizeof($eventCounts) > 0) {
+                    echo "<thead><tr><th>Rank</th><th>Member</th><th>Total Events Attended</th></tr></thead>";
+                    echo "<tbody>";
+                    $count = 1;
+                    foreach ($eventCounts as $key => $eventCount) {
+                        $totalEvents = $key;
+                        $firstName = $eventCount[1];
+                        $lastName = $eventCount[2];
+                        $name = $firstName . ' ' . $lastName;
+                        echo "<tr>";
+                        echo "<td>" . $count . "</td>";
+                        echo "<td>" . $name . "</td>";
+                        echo "<td>" . $totalEvents . "</td></tr>";
+                        $count++;
+                    }
+                    echo "</tbody>";
+                } else {
+                    echo "<tbody><tr><td>No events attended.</td></tr></tbody>";
+                }
+                ?>
+            </table>
+        </div>
+    </div>
+</div>
+<?php require "partials/footer.php"; ?>
+<?php require "partials/scripts.php"; ?>
+</body>
+
+</html>

--- a/memberProfile.php
+++ b/memberProfile.php
@@ -214,6 +214,9 @@
                             $query->setFetchMode(PDO::FETCH_ASSOC);
 
                             $reckerPair = $query->fetch();
+                            if($reckerPair=="") {
+                                $reckerPair = array('firstName'=>"", 'lastName'=>"");
+                            }
 
                         ?>
                         <input type="text" class="form-control" size=15 maxlength=5 name="reckerPair" value="<?php echo($reckerPair['firstName'] . " " . $reckerPair['lastName']) ?>" <?php echo $readonlyStatus; ?>>

--- a/partials/header.php
+++ b/partials/header.php
@@ -34,6 +34,9 @@
 <!--                    <a class="nav-link btn-link" href="/media.php">Media</a>-->
 <!--                </li>-->
                 <li class="nav-item">
+                    <a class="nav-link btn-link" href="/allTimeEvents.php">Records</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link btn-link" href="/memberProfile.php">Profile</a>
                 </li>
                 <?php if($isSecretary == 1 || $isVP == 1 || $isEventAdmin == 1 || $isAdmin == 1) :?>

--- a/partials/header.php
+++ b/partials/header.php
@@ -30,14 +30,17 @@
                 <li class="nav-item">
                     <a class="nav-link btn-link" href="/families.php">Families</a>
                 </li>
-<!--                <li class="nav-item">-->
-<!--                    <a class="nav-link btn-link" href="/media.php">Media</a>-->
-<!--                </li>-->
-                <li class="nav-item">
-                    <a class="nav-link btn-link" href="/allTimeEvents.php">Records</a>
-                </li>
                 <li class="nav-item">
                     <a class="nav-link btn-link" href="/memberProfile.php">Profile</a>
+                </li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Records
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                        <a class="dropdown-item" href="/allTimeEvents.php">All Time Events</a>
+                        <a class="dropdown-item" href="/pointsLeaders.php">Point Leaders</a>
+                    </div>
                 </li>
                 <?php if($isSecretary == 1 || $isVP == 1 || $isEventAdmin == 1 || $isAdmin == 1) :?>
                 <li class="nav-item dropdown">

--- a/partials/header.php
+++ b/partials/header.php
@@ -33,7 +33,7 @@
                 <li class="nav-item">
                     <a class="nav-link btn-link" href="/memberProfile.php">Profile</a>
                 </li>
-                <li class="nav-item dropdown">
+                <!--<li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Records
                     </a>
@@ -41,7 +41,7 @@
                         <a class="dropdown-item" href="/allTimeEvents.php">All Time Events</a>
                         <a class="dropdown-item" href="/pointsLeaders.php">Point Leaders</a>
                     </div>
-                </li>
+                </li>-->
                 <?php if($isSecretary == 1 || $isVP == 1 || $isEventAdmin == 1 || $isAdmin == 1) :?>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/pointsLeaders.php
+++ b/pointsLeaders.php
@@ -1,0 +1,54 @@
+<?php
+require "logged_in_check.php";
+require "database_connect.php";
+require "set_session_vars_short.php";
+$pageTitle = "All Time Events";
+?>
+
+<?php
+$pointsInfo = [];
+$pointsInfo["Spring 2023"] = array("Keshav Ramanathan", 1112, "Matthew Aronin", 1163, "Austin Gies", 1105);
+$pointsInfo["Fall 2022"] = array("Keshav Ramanathan", 1112, "Reid Spencer", 1143, "Charlie Hammer", 1127);
+$pointsInfo["Spring 2022"] = array("Jen O'Brien", 1097, "Keshav Ramanathan", 1112, "Matthew Kistner", 1162);
+$pointsInfo["Fall 2021"] = array("Keshav Ramanathan", 1112, "Caroline Means", 1064, "Charlie Hammer", 1127);
+$pointsInfo["Spring 2021"] = array("Charlie Hammer", 1127, "Caroline Means", 1064, "Keshav Ramanathan", 1112);
+?>
+
+<!DOCTYPE html>
+<html>
+<?php require "partials/head.php"; ?>
+<body>
+<?php require "partials/header.php"; ?>
+
+<div class="container">
+    <div class="row mb-3">
+        <div class="col-12">
+            <table class="table table-hover table-sm mb-3">
+                <?php
+                echo "<thead><tr><th>Semester</th><th>1st Place</th><th>2nd Place</th><th>3rd Place</th></tr></thead>";
+                echo "<tbody>";
+                    foreach ($pointsInfo as $key => $semesterInfo) {
+                        $semester = $key;
+                        $place1 = $semesterInfo[0];
+                        $place1ID = $semesterInfo[1];
+                        $place2 = $semesterInfo[2];
+                        $place2ID = $semesterInfo[3];
+                        $place3 = $semesterInfo[4];
+                        $place3ID = $semesterInfo[5];
+                        echo "<tr>";
+                        echo "<td>" . $semester . "</td>";
+                        echo "<td>" . '<a href="/memberProfile.php?memberId=' . $place1ID . '">' . $place1 . '</a>' . "</td>";
+                        echo "<td>" . '<a href="/memberProfile.php?memberId=' . $place2ID . '">' . $place2 . '</a>' . "</td>";
+                        echo "<td>" . '<a href="/memberProfile.php?memberId=' . $place3ID . '">' . $place3 . '</a>' . "</td></tr>";
+                    }
+                    echo "</tbody>";
+                ?>
+            </table>
+        </div>
+    </div>
+</div>
+<?php require "partials/footer.php"; ?>
+<?php require "partials/scripts.php"; ?>
+</body>
+
+</html>

--- a/pointsLeaders.php
+++ b/pointsLeaders.php
@@ -19,7 +19,9 @@ $pointsInfo["Spring 2021"] = array("Charlie Hammer", 1127, "Caroline Means", 106
 <?php require "partials/head.php"; ?>
 <body>
 <?php require "partials/header.php"; ?>
-
+<div class="container">
+    <h2>Winners' Circle</h2>
+</div>
 <div class="container">
     <div class="row mb-3">
         <div class="col-12">

--- a/stats.php
+++ b/stats.php
@@ -11,7 +11,12 @@
 <div class="container">
     <h2>Events Stats</h2>
     <div class="row mb-3">
-
+        <div class="col-12">
+            <a href="/allTimeEvents.php" class="float-left">All-Time Events</a>
+        </div>
+        <div class="col-12">
+            <a href="/pointsLeaders.php" class="float-left">Winners' Circle</a>
+        </div>
     </div>
     <div class="row mb-3">
         <div class="col-8 offset-2">


### PR DESCRIPTION
1) Adding an all time events attended page; Keeps track in order of most events attended (Displays top 100). Also finds the % of events a person attended out of events they could attend (A rough way to try and account for time in the club for the total event count).
2) Added a semester by semester top 3 in the Points website. Done by hand since the points database gets cleared every semester, Starting from 2021 because that is the last time I remember the top 3.
3) Link each of these people to their member profile page (Just in case people wanted to see info idk)
4) Fixed a bug where someone who didn't list their big RP doesn't have an error show when someone else views their profile.